### PR TITLE
Remove unused keepalive-workflow action

### DIFF
--- a/.github/workflows/Checkin.yml
+++ b/.github/workflows/Checkin.yml
@@ -26,5 +26,3 @@ jobs:
         shell: bash
         run: |
           node main.js
-
-      - uses: gautamkrishnar/keepalive-workflow@v2


### PR DESCRIPTION
The keepalive-workflow action was no longer needed and has been removed to simplify the workflow configuration. This change does not impact the primary functionality of the workflow.