### PR TITLE
Update cron schedule in GitHub Actions workflow

### DIFF
--- a/.github/workflows/Checkin.yml
+++ b/.github/workflows/Checkin.yml
@@ -3,7 +3,7 @@ name: HIFINI-Auto-Checkin
 on:
   schedule:
     # UTC+8 ??:??
-    - cron: "45 23 * * *"
+    - cron: "15 02 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Adjusted the cron schedule for the Checkin workflow from 23:45 UTC to 02:15 UTC. This ensures better alignment with operational requirements or time zone preferences.