### PR TITLE
Update scheduled time for Checkin workflow

### DIFF
--- a/.github/workflows/Checkin.yml
+++ b/.github/workflows/Checkin.yml
@@ -3,7 +3,7 @@ name: HIFINI-Auto-Checkin
 on:
   schedule:
     # UTC+8 ??:??
-    - cron: "15 02 * * *"
+    - cron: "15 14 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Adjusted the cron schedule for the Checkin workflow from 02:15 UTC to 14:15 UTC. This change aligns the job timing with updated requirements or preferences.